### PR TITLE
Set the baseURL of axios

### DIFF
--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -1,6 +1,6 @@
 export default function ({ $axios, redirect }) {
   // Set baseURL
-  // $axios.setBaseURL(process.env.baseURL || 'http://localhost:3000')
+  $axios.setBaseURL(process.env.baseURL || 'http://localhost:3000')
 
   // Add Interceptor
   $axios.onError((error) => {


### PR DESCRIPTION
- Set the request `baseURL` of axios plugin
- Reference
   - [API/Extending Axios](https://axios.nuxtjs.org/extend#new-axios-instance)
   - [API/Helpers](https://axios.nuxtjs.org/extend#new-axios-instance)

Close #9 