### PR TITLE
Fixed the bug of acive link of /event link

### DIFF
--- a/components/dashboard/sidebar.vue
+++ b/components/dashboard/sidebar.vue
@@ -13,7 +13,7 @@
         <b-nav-item to="/overview" exact-active-class="active">
           Overview
         </b-nav-item>
-        <b-nav-item to="/event" exact-active-class="active">
+        <b-nav-item to="/event" active-class="active">
           Event
         </b-nav-item>
         <b-nav-item exact-active-class="active">


### PR DESCRIPTION
## Work List
- Fixed the bug of event link's active class
   - event link's active target page: `/event`, `/event/:id`