### PR TITLE
Feature/enhance chart layout

### DIFF
--- a/assets/styles/custom/_variables.scss
+++ b/assets/styles/custom/_variables.scss
@@ -33,4 +33,4 @@ $chart-container-sizes: map-merge(
   $chart-container-sizes
 );
 
-$chart-container-maxSizes: 100, 200, 300, 400
+$chart-container-maxSizes: 100, 200, 300

--- a/components/event/details/salesAnalytics.vue
+++ b/components/event/details/salesAnalytics.vue
@@ -28,7 +28,7 @@
           <b-col cols class="flex-grow-0">
             <div id="salesAnalytics-chart-lengend" class="d-flex justify-content-around w-50 mx-auto" />
           </b-col>
-          <b-col cols class="chart-container chart-h-md-30 chart-min-h-xl-250">
+          <b-col cols class="chart-container chart-h-md-20 chart-h-lg-30 chart-min-h-xl-250">
             <client-only>
               <LazyBarChart
                 canvas-id="salesAnalytics-chart"

--- a/components/event/details/trafficSoureces.vue
+++ b/components/event/details/trafficSoureces.vue
@@ -5,7 +5,7 @@
       class="pb-3"
     >
       <b-row id="traffic-chart-wrapper" align-v="center" class="h-100">
-        <b-col cols="6" md="7" class="chart-container chart-h-md-45 chart-h-xl-35 chart-max-h-xl-250">
+        <b-col cols="6" lg="7" class="chart-container chart-h-md-25 chart-h-lg-45 chart-h-xl-35 chart-max-h-md-150 chart-max-h-lg-200 chart-max-h-xl-250">
           <client-only>
             <LazyDoughnutChart
               ref="traffic-chart"
@@ -21,7 +21,7 @@
             />
           </client-only>
         </b-col>
-        <b-col cols="6" md="5">
+        <b-col cols="6" lg="5">
           <div id="traffic-chart-lengend" />
         </b-col>
       </b-row>

--- a/components/event/details/visitorsAnalytics.vue
+++ b/components/event/details/visitorsAnalytics.vue
@@ -5,7 +5,7 @@
       class="pb-3"
     >
       <b-row id="view-chart-wrapper" align-v="center" class="h-100">
-        <b-col cols="6" md="7" class="chart-container chart-h-md-45 chart-h-xl-35 chart-max-h-xl-250">
+        <b-col cols="6" lg="7" class="chart-container chart-h-md-25 chart-h-lg-45 chart-h-xl-35 chart-max-h-md-150 chart-max-h-lg-200 chart-max-h-xl-250">
           <client-only>
             <LazyPieChart
               ref="view-chart"
@@ -22,7 +22,7 @@
             />
           </client-only>
         </b-col>
-        <b-col cols="6" md="5">
+        <b-col cols="6" lg="5">
           <div id="view-chart-lengend" />
         </b-col>
       </b-row>

--- a/components/event/status.vue
+++ b/components/event/status.vue
@@ -1,6 +1,6 @@
 <template>
   <b-row>
-    <b-col cols md="4" class="mb-4 mb-md-0">
+    <b-col cols md="5" lg="4" class="mb-4 mb-md-0">
       <dash-card title="Date Created" class="pb-3 h-100">
         <b-row>
           <b-col cols>
@@ -26,7 +26,7 @@
         </b-row>
       </dash-card>
     </b-col>
-    <b-col cols md="4" class="mb-4 mb-md-0">
+    <b-col cols md="auto" lg="4" class="mb-4 mb-md-0 flex-md-grow-1 flex-lg-grow-0">
       <dash-card title="Open" class="h-100">
         <b-row>
           <b-col cols>
@@ -52,7 +52,7 @@
         </template>
       </dash-card>
     </b-col>
-    <b-col cols md="4">
+    <b-col cols md="auto" lg="4" class="flex-md-grow-1 flex-lg-grow-0">
       <dash-card title="Close" class="h-100">
         <b-row>
           <b-col cols>

--- a/components/users/statics.vue
+++ b/components/users/statics.vue
@@ -55,7 +55,7 @@
         <b-col cols class="pb-4 h-50">
           <dash-card title="Weekly Traffic" class="h-100 pb-3 pb-md-0">
             <b-row id="weeklyTraffic-chart-wrapper" align-v="center" class="h-100">
-              <b-col cols class="chart-container chart-h-20 chart-h-md-45 chart-max-h-xl-250">
+              <b-col cols class="chart-container chart-h-20 chart-h-md-25 chart-h-lg-45 chart-max-h-md-250">
                 <LazyLineChart
                   canvas-id="weeklyTraffic-chart"
                   :data="weekTrafficDataset"
@@ -71,7 +71,7 @@
         <b-col cols>
           <dash-card title="24 Hours Traffic" :useicon="false" class="h-100 pb-3 pb-md-0">
             <b-row id="hourlyTraffic-chart-wrapper" align-v="center" class="h-100">
-              <b-col cols class="chart-container chart-h-20 chart-h-md-45 chart-max-h-xl-250">
+              <b-col cols class="chart-container chart-h-20 chart-h-md-25 chart-h-lg-45 chart-max-h-md-250">
                 <LazyBarChart
                   canvas-id="hourlyTraffic-chart"
                   :data="timeTrafficDataset"

--- a/pages/overview.vue
+++ b/pages/overview.vue
@@ -5,7 +5,7 @@
       description="Your bounce rate increased by 5.25% over the past 30 days."
     />
     <b-row class="mb-4">
-      <b-col cols md="6">
+      <b-col cols lg="6" class="mb-md-4 mb-lg-0">
         <b-row>
           <b-col cols md="6" class="mb-4">
             <dash-card
@@ -32,9 +32,9 @@
             />
           </b-col>
           <b-col cols md="6" class="mb-4 mb-md-0">
-            <dash-card title="Traffic Share" class="h-100">
-              <b-row id="traffic-share-chart-wrapper" align-v="center" class="h-100 pb-3">
-                <b-col cols md="6" class="chart-container chart-h-20 chart-h-md-10 chart-min-h-md-100">
+            <dash-card title="Traffic Share" class="h-100 pb-md-3 pb-lg-0">
+              <b-row id="traffic-share-chart-wrapper" align-v="center" class="h-100 pb-lg-3">
+                <b-col cols md="6" class="chart-container chart-h-20 chart-h-md-5 chart-h-lg-10 chart-min-h-md-100">
                   <LazyPieChart
                     canvas-id="traffic-share-chart"
                     :data="shares"
@@ -57,10 +57,10 @@
           </b-col>
         </b-row>
       </b-col>
-      <b-col cols md="6">
-        <dash-card title="Sales" class="mb-4 mb-md-0 h-100">
+      <b-col cols lg="6">
+        <dash-card title="Sales" class="mb-4 mb-md-0 h-100 pb-md-3 pb-lg-0">
           <b-row id="sales-chart-wrapper" align-v="center" class="h-100">
-            <b-col cols class="chart-container chart-h-30 chart-h-md-40 chart-h-xl-25 chart-min-h-md-250">
+            <b-col cols class="chart-container chart-h-30 chart-h-md-30 chart-h-lg-40 chart-h-xl-25 chart-max-h-md-250 chart-min-h-lg-250">
               <LazyLineChart
                 canvas-id="sales-chart"
                 :data="sales"
@@ -79,7 +79,7 @@
       <b-col cols md="6" class="mb-4 mb-md-0">
         <dash-card title="Traffic Channels" class="h-100 pb-3">
           <b-row id="trafficChannel-chart-wrapper" align-v="center" class="h-100">
-            <b-col cols class="chart-container chart-h-30 chart-h-md-40 chart-h-xl-30 chart-min-h-md-250 chart-max-h-xl-450">
+            <b-col cols class="chart-container chart-h-30 chart-h-md-20 chart-h-lg-40 chart-h-xl-30 chart-min-h-md-200 chart-min-h-lg-250 chart-max-h-xl-450">
               <LazyBarChart
                 canvas-id="trafficChannel-chart"
                 :data="channels"
@@ -96,7 +96,7 @@
       <b-col cols md="6">
         <dash-card title="Visit by Notification" class="h-100 pb-3">
           <b-row id="noti-chart-wrapper" align-v="center" class="h-100">
-            <b-col cols md="7" class="chart-container chart-h-30 chart-h-md-30 chart-h-xl-20 chart-min-h-md-250">
+            <b-col cols md="6" lg="7" class="chart-container chart-h-30 chart-h-md-15 chart-h-lg-30 chart-h-xl-20 chart-max-h-md-150 chart-min-h-lg-250 mb-md-3 mb-lg-0">
               <LazyPolarArea
                 canvas-id="noti-chart"
                 :data="noti"
@@ -299,18 +299,31 @@ export default {
       </svg>`
       }
       const text = [...ds.data].reverse().reduce((legendHtml, data, d) => {
+        // legendHtml.push(
+        // `<div id="noti-legend-${d}"
+        //   data-chart-dataset="0" data-chart-idx="${d}" data-legend-role="parent"
+        //   data-legend-parent="noti-legend-${d}"
+        //   class="d-flex flex-column flex-lg-row align-items-center user-select-none mb-lg-2"
+        //   style="font-size: 0.8rem;color:${ds.backgroundColor[d]};"
+        // >
+        //   <div class="d-flex align-items-center mb-2" data-legend-parent="noti-legend-${d}">
+        //     <span class="legend-icon mr-2 mr-lg-0">${icons[labels[d]]}</span>
+        //     <span class="ml-lg-2">${labels[d]}</span>
+        //   </div>
+        //   <div data-legend-parent="noti-legend-${d}" class="legend-value mx-auto ml-lg-auto mr-lg-0">${data} %</div>
+        // </div>`)
         legendHtml.push(
         `<div id="noti-legend-${d}"
           data-chart-dataset="0" data-chart-idx="${d}" data-legend-role="parent"
           data-legend-parent="noti-legend-${d}"
-          class="d-flex flex-column flex-md-row align-items-center user-select-none mb-md-2"
+          class="d-flex flex-column flex-md-row align-items-center user-select-none mb-lg-2"
           style="font-size: 0.8rem;color:${ds.backgroundColor[d]};"
         >
           <div class="d-flex align-items-center mb-2" data-legend-parent="noti-legend-${d}">
             <span class="legend-icon mr-2 mr-md-0">${icons[labels[d]]}</span>
             <span class="ml-md-2">${labels[d]}</span>
           </div>
-          <div data-legend-parent="noti-legend-${d}" class="legend-value mx-auto ml-md-auto mr-md-0">${data} %</div>
+          <div data-legend-parent="noti-legend-${d}" class="legend-value mx-auto ml-lg-auto mr-md-0">${data} %</div>
         </div>`)
         return legendHtml
       }, [])


### PR DESCRIPTION
## Work List
- Enhanced a feature of bootstrap layout breakpoints
  - new breakpoint: `xxl` (1366px)
  - breakpoints: `xs, sm, md, lg, xl, xxl`
- Create a feature of chart container size using `height`
   - Set the chart **dynamic height** using css `max-height` and `min-height`
      - `chart-h-[breakpoint]-[height]`
      - height: `10vh, 20vh, 30vh, 40vh, 50vh`
   - Set the chart **size range** using css `max-height` and `min-height`
      - `chart-[max|min]-h-[breakpoint]-[range-height]`
      - range-height: `0, 100px, 200px, 300px, 400px`