### PR TITLE
Feature/enhance chart size

### DIFF
--- a/assets/styles/custom/_variables.scss
+++ b/assets/styles/custom/_variables.scss
@@ -33,4 +33,4 @@ $chart-container-sizes: map-merge(
   $chart-container-sizes
 );
 
-$chart-container-maxSizes: 100, 200, 300
+$chart-container-maxSizes: 100, 200, 300, 400, 500

--- a/assets/styles/custom/chart.scss
+++ b/assets/styles/custom/chart.scss
@@ -26,10 +26,14 @@
     @include media-breakpoint-up($breakpoint) {
       $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
       $half: $size - 50;
-      .chart-max-h#{$infix}-#{$half} { max-height: #{$half}px !important; }
-      .chart-max-h#{$infix}-#{$size} { max-height: #{$size}px !important; }
-      .chart-min-h#{$infix}-#{$half} { min-height: #{$half}px !important; }
-      .chart-min-h#{$infix}-#{$size} { min-height: #{$size}px !important; }
+      .chart-range-h#{$infix}-#{$half} {
+        min-height: #{$half}px !important;
+        max-height: #{$half}px !important;
+      }
+      .chart-range-h#{$infix}-#{$size} {
+        min-height: #{$size}px !important;
+        max-height: #{$size}px !important;
+      }
     }
   }
 }

--- a/assets/styles/library/_library.scss
+++ b/assets/styles/library/_library.scss
@@ -4,7 +4,9 @@ $grid-breakpoints: (
   sm: 480px,
   md: 640px,
   lg: 992px,
-  xl: 1300px
+  xl: 1200px,
+  xxl: 1366px,
+  sxl: 1680px,
 );
 $enable-rounded: true;
 

--- a/components/event/details/salesAnalytics.vue
+++ b/components/event/details/salesAnalytics.vue
@@ -1,8 +1,8 @@
 <template>
   <b-row class="mb-4">
     <b-col cols md="4" class="mb-4 mb-md-0">
-      <b-row no-gutters class="flex-column">
-        <b-col cols class="mb-4">
+      <b-row class="flex-md-column">
+        <b-col cols sm="6" md class="mb-4 mb-sm-0 mb-md-4 pr-sm-3">
           <dash-card
             title="Total Views"
             class="pb-3"
@@ -11,7 +11,7 @@
             :rate="views.rate"
           />
         </b-col>
-        <b-col cols>
+        <b-col cols sm="6" md class="pl-sm-3">
           <dash-card
             title="Total Sales"
             class="pb-3"
@@ -28,7 +28,7 @@
           <b-col cols class="flex-grow-0">
             <div id="salesAnalytics-chart-lengend" class="d-flex justify-content-around w-50 mx-auto" />
           </b-col>
-          <b-col cols class="chart-container chart-h-md-20 chart-h-lg-30 chart-min-h-xl-250">
+          <b-col cols class="chart-container chart-h-10 chart-h-md-20 chart-h-lg-30 chart-range-h-200 chart-range-h-md-250">
             <client-only>
               <LazyBarChart
                 canvas-id="salesAnalytics-chart"
@@ -42,7 +42,7 @@
                 :legend-callback="salesAnalyticsLegendCb"
                 :use-custom-legend-click="true"
                 :custom-legend-click="salesAnalyticsLegendClick"
-                class="pb-3"
+                class="pb-3 pb-md-0"
                 responsive
                 tooltip
                 mixed

--- a/components/event/details/trafficSoureces.vue
+++ b/components/event/details/trafficSoureces.vue
@@ -5,7 +5,7 @@
       class="pb-3"
     >
       <b-row id="traffic-chart-wrapper" align-v="center" class="h-100">
-        <b-col cols="6" lg="7" class="chart-container chart-h-md-25 chart-h-lg-45 chart-h-xl-35 chart-max-h-md-150 chart-max-h-lg-200 chart-max-h-xl-250">
+        <b-col cols="6" lg="7" class="chart-container chart-h-25 chart-range-h-sm-150 chart-range-h-lg-200">
           <client-only>
             <LazyDoughnutChart
               ref="traffic-chart"

--- a/components/event/details/visitorsAnalytics.vue
+++ b/components/event/details/visitorsAnalytics.vue
@@ -5,7 +5,7 @@
       class="pb-3"
     >
       <b-row id="view-chart-wrapper" align-v="center" class="h-100">
-        <b-col cols="6" lg="7" class="chart-container chart-h-md-25 chart-h-lg-45 chart-h-xl-35 chart-max-h-md-150 chart-max-h-lg-200 chart-max-h-xl-250">
+        <b-col cols="6" lg="7" class="chart-container chart-h-25 chart-range-h-sm-150 chart-range-h-lg-200">
           <client-only>
             <LazyPieChart
               ref="view-chart"

--- a/components/event/status.vue
+++ b/components/event/status.vue
@@ -26,7 +26,7 @@
         </b-row>
       </dash-card>
     </b-col>
-    <b-col cols md="auto" lg="4" class="mb-4 mb-md-0 flex-md-grow-1 flex-lg-grow-0">
+    <b-col cols sm="6" md="auto" lg="4" class="mb-4 mb-sm-0 flex-md-grow-1 flex-lg-grow-0">
       <dash-card title="Open" class="h-100">
         <b-row>
           <b-col cols>
@@ -52,8 +52,8 @@
         </template>
       </dash-card>
     </b-col>
-    <b-col cols md="auto" lg="4" class="flex-md-grow-1 flex-lg-grow-0">
-      <dash-card title="Close" class="h-100">
+    <b-col cols sm="6" md="auto" lg="4" class="flex-md-grow-1 flex-lg-grow-0">
+      <dash-card title="Close" class="h-md-100">
         <b-row>
           <b-col cols>
             <div :class="dateClass" style="margin-bottom: -.2rem;">{{ closeStatus.date }}</div>

--- a/components/users/statics.vue
+++ b/components/users/statics.vue
@@ -1,16 +1,24 @@
 <template>
   <b-row>
-    <b-col cols md="4" class="mb-4 mb-md-0">
-      <b-row class="flex-column h-100">
-        <b-col cols>
+    <b-col cols lg="4" xxl="12" class="mb-4 mb-lg-0">
+      <b-row class="flex-lg-column flex-xxl-row mb-xxl-4">
+        <b-col cols sm="6" lg="12" xxl="4" class="mb-sm-4 mb-lg-0">
           <dash-card
             title="Users"
             icon="people-fill"
             :index="total.value"
             :rate="total.rate"
+            class="mb-xxl-4"
+          />
+          <dash-card
+            title="New Users"
+            icon="person-check-fill"
+            :index="newUsers.value"
+            :rate="newUsers.rate"
+            class="d-none d-xxl-flex"
           />
         </b-col>
-        <b-col cols class="py-4">
+        <b-col cols sm="6" lg="12" xxl="4" class="d-block d-xxl-none py-4 py-sm-0 py-lg-4">
           <dash-card
             title="New Users"
             icon="person-check-fill"
@@ -50,12 +58,12 @@
         </b-col>
       </b-row>
     </b-col>
-    <b-col cols md="8">
-      <b-row class="flex-column h-100">
-        <b-col cols class="pb-4 h-50">
-          <dash-card title="Weekly Traffic" class="h-100 pb-3 pb-md-0">
-            <b-row id="weeklyTraffic-chart-wrapper" align-v="center" class="h-100">
-              <b-col cols class="chart-container chart-h-20 chart-h-md-25 chart-h-lg-45 chart-max-h-md-250">
+    <b-col cols lg="8" xxl="12">
+      <b-row class="flex-column flex-xxl-row h-100 justify-content-lg-between justify-content-xxl-start">
+        <b-col cols xxl="6" class="h-lg-50 h-xxl-100 pb-4 pb-lg-0">
+          <dash-card title="Weekly Traffic" class="h-100 pb-3 pb-lg-0">
+            <b-row id="weeklyTraffic-chart-wrapper" align-v="center" class="h-100 pb-xxl-3">
+              <b-col cols class="chart-container chart-h-20 chart-range-h-200 chart-range-h-md-300 chart-range-h-lg-250 chart-range-h-xxl-300">
                 <LazyLineChart
                   canvas-id="weeklyTraffic-chart"
                   :data="weekTrafficDataset"
@@ -68,10 +76,10 @@
             </b-row>
           </dash-card>
         </b-col>
-        <b-col cols>
-          <dash-card title="24 Hours Traffic" :useicon="false" class="h-100 pb-3 pb-md-0">
+        <b-col cols xxl="6">
+          <dash-card title="24 Hours Traffic" :useicon="false" class="h-100 pb-3 pb-lg-0 pb-xxl-3">
             <b-row id="hourlyTraffic-chart-wrapper" align-v="center" class="h-100">
-              <b-col cols class="chart-container chart-h-20 chart-h-md-25 chart-h-lg-45 chart-max-h-md-250">
+              <b-col cols class="chart-container chart-h-20 chart-range-h-200 chart-range-h-md-250 chart-range-h-xxl-300">
                 <LazyBarChart
                   canvas-id="hourlyTraffic-chart"
                   :data="timeTrafficDataset"

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -69,7 +69,10 @@ export default {
   bootstrapVue: {
     bootstrapCSS: false, // Or `css: false`
     bootstrapVueCSS: false, // Or `bvCSS: false`
-    icons: true
+    icons: true,
+    config: {
+      breakpoints: ['xs', 'sm', 'md', 'lg', 'xl', 'xxl']
+    }
   },
 
   serverMiddleware: [

--- a/pages/overview.vue
+++ b/pages/overview.vue
@@ -4,10 +4,10 @@
       title="Analytics Overview"
       description="Your bounce rate increased by 5.25% over the past 30 days."
     />
-    <b-row class="mb-4">
+    <b-row class="mb-4 h-xxl-100">
       <b-col cols lg="6" class="mb-md-4 mb-lg-0">
         <b-row>
-          <b-col cols md="6" class="mb-4">
+          <b-col cols="12" md="6" class="mb-4 mb-xxl-auto">
             <dash-card
               title="Total visits"
               icon="people-fill"
@@ -15,7 +15,7 @@
               :rate="totalVists.rate"
             />
           </b-col>
-          <b-col cols md="6" class="mb-4">
+          <b-col cols="12" md="6" class="mb-4">
             <dash-card
               title="New Users"
               :index="newUsers.users"
@@ -23,7 +23,7 @@
               icon="person-plus-fill"
             />
           </b-col>
-          <b-col cols md="6" class="mb-4 mb-md-0">
+          <b-col cols="12" md="6" class="mb-4 mb-md-0">
             <dash-card
               title="Active Users"
               icon="person-check-fill"
@@ -31,10 +31,10 @@
               :rate="totalVists.rate"
             />
           </b-col>
-          <b-col cols md="6" class="mb-4 mb-md-0">
-            <dash-card title="Traffic Share" class="h-100 pb-md-3 pb-lg-0">
-              <b-row id="traffic-share-chart-wrapper" align-v="center" class="h-100 pb-lg-3">
-                <b-col cols md="6" class="chart-container chart-h-20 chart-h-md-5 chart-h-lg-10 chart-min-h-md-100">
+          <b-col cols="12" md="6" class="mb-4 mb-md-0">
+            <dash-card title="Traffic Share" class="h-100 pb-3 pb-lg-0">
+              <b-row id="traffic-share-chart-wrapper" align-v="center" class="flex-column flex-sm-row h-100 pb-lg-3">
+                <b-col cols="6" md="6" class="chart-container chart-h-20 chart-h-md-5 chart-h-lg-10 chart-range-h-100 chart-range-sm-h-200 chart-range-h-md-100 mb-3 mb-sm-0 mt-xxl-0">
                   <LazyPieChart
                     canvas-id="traffic-share-chart"
                     :data="shares"
@@ -49,8 +49,8 @@
                     use-data-label
                   />
                 </b-col>
-                <b-col cols>
-                  <div id="trafficShare-chart-lengend" class="d-flex flex-md-column justify-content-around mt-4 my-md-0" />
+                <b-col cols md="6">
+                  <div id="trafficShare-chart-lengend" class="d-flex flex-sm-column justify-content-around" />
                 </b-col>
               </b-row>
             </dash-card>
@@ -60,7 +60,7 @@
       <b-col cols lg="6">
         <dash-card title="Sales" class="mb-4 mb-md-0 h-100 pb-md-3 pb-lg-0">
           <b-row id="sales-chart-wrapper" align-v="center" class="h-100">
-            <b-col cols class="chart-container chart-h-30 chart-h-md-30 chart-h-lg-40 chart-h-xl-25 chart-max-h-md-250 chart-min-h-lg-250">
+            <b-col cols class="chart-container chart-h-30 chart-h-md-30 chart-h-lg-40 chart-h-xl-25 chart-range-h-250 chart-range-h-xxl-300 chart-range-h-sxl-250">
               <LazyLineChart
                 canvas-id="sales-chart"
                 :data="sales"
@@ -69,6 +69,7 @@
                 user-x-axes-as-time
                 tooltip
                 responsive
+                class="pb-xxl-3"
               />
             </b-col>
           </b-row>
@@ -76,10 +77,10 @@
       </b-col>
     </b-row>
     <b-row class="mb-4">
-      <b-col cols md="6" class="mb-4 mb-md-0">
+      <b-col cols="12" md="6" class="mb-4 mb-md-0">
         <dash-card title="Traffic Channels" class="h-100 pb-3">
           <b-row id="trafficChannel-chart-wrapper" align-v="center" class="h-100">
-            <b-col cols class="chart-container chart-h-30 chart-h-md-20 chart-h-lg-40 chart-h-xl-30 chart-min-h-md-200 chart-min-h-lg-250 chart-max-h-xl-450">
+            <b-col cols class="chart-container chart-h-30 chart-h-md-20 chart-h-lg-40 chart-range-h-200 chart-range-h-250 chart-range-h-md-200 chart-range-h-lg-250">
               <LazyBarChart
                 canvas-id="trafficChannel-chart"
                 :data="channels"
@@ -93,10 +94,10 @@
           </b-row>
         </dash-card>
       </b-col>
-      <b-col cols md="6">
+      <b-col cols="12" md="6">
         <dash-card title="Visit by Notification" class="h-100 pb-3">
           <b-row id="noti-chart-wrapper" align-v="center" class="h-100">
-            <b-col cols md="6" lg="7" class="chart-container chart-h-30 chart-h-md-15 chart-h-lg-30 chart-h-xl-20 chart-max-h-md-150 chart-min-h-lg-250 mb-md-3 mb-lg-0">
+            <b-col cols sm="6" lg="6" class="chart-container chart-h-30 chart-h-md-15 chart-h-lg-30 chart-h-xl-20 chart-range-h-200 chart-range-h-md-150 chart-range-h-xl-200 chart-range-h-xxl-200 chart-range-h-sxl-250 mx-md-0">
               <LazyPolarArea
                 canvas-id="noti-chart"
                 :data="noti"
@@ -111,8 +112,15 @@
                 tooltip
               />
             </b-col>
-            <b-col cols>
-              <div id="noti-chart-lengend" class="h-md-100 d-flex flex-md-column justify-content-between mt-4 my-md-0" />
+            <b-col
+              cols
+              sm="5"
+              md="6"
+              offset-xxl="1"
+              xxl="4"
+              class="h-sm-100 chart-range-h-sm-150"
+            >
+              <div id="noti-chart-lengend" class="h-md-100 d-flex flex-sm-column justify-content-between mt-4 my-sm-0 h-100" />
             </b-col>
           </b-row>
         </dash-card>
@@ -266,7 +274,7 @@ export default {
       const text = ds.data.reduce((legendHtml, data, d) => {
         legendHtml.push(`<div id="trafficShare-legend-${d}"
           data-legend-parent="trafficShare-legend-${d}" data-chart-dataset="0" data-chart-idx="${d}"
-          class="d-flex align-items-center mb-2 user-select-none" style="color:${ds.backgroundColor[d]}; font-size: 0.8rem">
+          class="d-flex align-items-center ${d === 0 ? 'mb-sm-2' : ''} user-select-none" style="color:${ds.backgroundColor[d]}; font-size: 0.8rem">
           ${icons[labels[d]]}
           <span class="ml-2">${labels[d]}</span>
           <span class="d-md-none legend-value ml-2">(${data} %)</span>
@@ -299,31 +307,18 @@ export default {
       </svg>`
       }
       const text = [...ds.data].reverse().reduce((legendHtml, data, d) => {
-        // legendHtml.push(
-        // `<div id="noti-legend-${d}"
-        //   data-chart-dataset="0" data-chart-idx="${d}" data-legend-role="parent"
-        //   data-legend-parent="noti-legend-${d}"
-        //   class="d-flex flex-column flex-lg-row align-items-center user-select-none mb-lg-2"
-        //   style="font-size: 0.8rem;color:${ds.backgroundColor[d]};"
-        // >
-        //   <div class="d-flex align-items-center mb-2" data-legend-parent="noti-legend-${d}">
-        //     <span class="legend-icon mr-2 mr-lg-0">${icons[labels[d]]}</span>
-        //     <span class="ml-lg-2">${labels[d]}</span>
-        //   </div>
-        //   <div data-legend-parent="noti-legend-${d}" class="legend-value mx-auto ml-lg-auto mr-lg-0">${data} %</div>
-        // </div>`)
         legendHtml.push(
         `<div id="noti-legend-${d}"
           data-chart-dataset="0" data-chart-idx="${d}" data-legend-role="parent"
           data-legend-parent="noti-legend-${d}"
-          class="d-flex flex-column flex-md-row align-items-center user-select-none mb-lg-2"
+          class="d-flex flex-column flex-sm-row align-items-center user-select-none"
           style="font-size: 0.8rem;color:${ds.backgroundColor[d]};"
         >
-          <div class="d-flex align-items-center mb-2" data-legend-parent="noti-legend-${d}">
+          <div class="d-flex align-items-center ${d === 0 ? '' : 'mt-2'} mt-sm-0" data-legend-parent="noti-legend-${d}">
             <span class="legend-icon mr-2 mr-md-0">${icons[labels[d]]}</span>
             <span class="ml-md-2">${labels[d]}</span>
           </div>
-          <div data-legend-parent="noti-legend-${d}" class="legend-value mx-auto ml-lg-auto mr-md-0">${data} %</div>
+          <div data-legend-parent="noti-legend-${d}" class="legend-value mx-auto ml-sm-auto mr-sm-0">${data} %</div>
         </div>`)
         return legendHtml
       }, [])


### PR DESCRIPTION
## Work List
- Enhanced a feature of bootstrap layout breakpoints
- Create a feature of chart container size using `height`
   - Set the chart **dynamic height** using css `max-height` and `min-height`
      - `chart-h-[breakpoint]-[height]`
      - height: `10: 10vh, 20: 20vh, 30: 30vh, 40: 40vh, 50: 50vh`
   - Set the chart **size range** using css `max-height` and `min-height`
      - `chart-range-h-[breakpoint]-[range-height]`
      - range-height: `100px, 200px, 300px, 400px, 400px`

### new breakpoint
- breakpoints: `xs, sm, md, lg, xl, xxl, sxl`
- new breakpoint
  - `xl` (1200px)
  - `xxl` (1366px)
  - `sxl` (1680px)

refer #62 