### PR TITLE
Feature/enhance chart computing scale

### DIFF
--- a/api/lib/users.js
+++ b/api/lib/users.js
@@ -8,7 +8,7 @@ export function createUsersTraffic (startAt, count = 7) {
   return new Promise((resolve, reject) => {
     try {
       const serialTrafficDays = createDateArray(startAt, null, count)
-      const serialTrafficData = createSerialRandom(20, 45, count, false)
+      const serialTrafficData = createSerialRandom(100, 170, count)
       const serialTraffic = serialTrafficDays.reduce((merged, day, d) => {
         merged.push({ [day]: serialTrafficData[d] })
         return merged

--- a/api/utility/createRandom.js
+++ b/api/utility/createRandom.js
@@ -64,8 +64,8 @@ function createSerialRandomByUnique (min, max, unique, count = 7) {
   const overWeight = unique > randomSerialSum ? unique - randomSerialSum : randomSerialSum - unique
   const overWeightShare = Number(Number.parseFloat(overWeight / count).toFixed(2))
   randomSerial = randomSerial.reduce((serial, ele) => {
-    const computed = overWeightShare + ele
-    serial.push(Number.parseFloat(computed.toFixed(2)))
+    const computed = Math.floor(overWeightShare + ele)
+    serial.push(computed)
     return serial
   }, [])
   return randomSerial

--- a/components/chart/BarChart.vue
+++ b/components/chart/BarChart.vue
@@ -5,11 +5,13 @@
 <script>
 import defaultProps from "~/mixins/chart/defaultProps_linebar"
 import createChartColor from "~/mixins/chart/createChartColor"
+import computingYScaleBarLine from "~/mixins/chart/computingScaleTicksBarLine"
 
 export default {
   mixins: [
     defaultProps,
-    createChartColor
+    createChartColor,
+    computingYScaleBarLine
   ],
   props: {
     singleColor: {
@@ -161,39 +163,12 @@ export default {
         const yScale = options.scales.yAxes
         let ranges = this.data.datasets.reduce((ranges, { data }, d) => {
           const isBeginAtZero = !!yScale[d].ticks && yScale[d].ticks.beginAtZero
-          let [max, min] = [Math.max.apply(null, data), Math.min.apply(null, data)]
-          const [maxWeight, minWeight] = [(max % 10 === 0) ? 10 : 5, (max % 10 === 0) ? 10 : 5]
-          max = Math.ceil(max / maxWeight) * maxWeight
-          min = isBeginAtZero ? 0 : Math.floor(min / minWeight) * minWeight
-          const diff = max - min
-          const [isStep5, isStep10] = [diff % 5 === 0, diff % 10 === 0]
-          ranges.push({ max, min, isStep5, isStep10, isBeginAtZero, diff })
+          const range = this.computeDatasetRange(data, isBeginAtZero)
+          ranges.push(range)
           return ranges
         }, [])
 
-        const isAllPassStep5 = ranges.every(({ isStep5 }) => isStep5 === true)
-        const isAllPassStep10 = ranges.every(({ isStep10 }) => isStep10 === true)
-        let commonStepWeight = null
-
-        if (isAllPassStep5 || isAllPassStep10) {
-          const diffs = ranges.map(({ diff }) => diff)
-          const maxDiff = Math.max.apply(null, diffs)
-          if (maxDiff >= 10) {
-            commonStepWeight = isAllPassStep5 && isAllPassStep10 ? 5 : isAllPassStep5 ? 5 : isAllPassStep10 ? 10 : 5
-          } else {
-            commonStepWeight = maxDiff % 5 === 0 ? 1 : maxDiff % 3 === 0 ? 3 : 2
-          }
-          ranges = ranges.map(({ min, max, diff }, r) => {
-            if (diff !== maxDiff) {
-              if (min >= maxDiff) {
-                min -= commonStepWeight
-              } else {
-                max += commonStepWeight
-              }
-            }
-            return { min, max, diff: max - min, stepSize: !commonStepWeight ? 0 : commonStepWeight }
-          })
-        }
+        ranges = this.computingYScale(ranges)
         ranges.forEach(({ max, min, beginAtZero, stepSize }, r) => {
           yScale[r].ticks = this.mergeOptions(yScale[r].ticks, { min, max, beginAtZero, stepSize })
         })

--- a/components/event/details/salesAnalytics.vue
+++ b/components/event/details/salesAnalytics.vue
@@ -44,7 +44,6 @@
                 use-data-label
                 class="pb-3 pb-md-0"
                 responsive
-                tooltip
                 mixed
                 compute-scale-axe="Y"
               />
@@ -101,12 +100,21 @@ export default {
             label: "Sales",
             data: this.sales.value,
             yAxisID: 'sales-yAxe',
-            fill: true,
+            fill: false,
             order: 1,
             datalabels: {
-              display: true,
-              align: 'end',
-              anchor: 'end'
+              display () {
+                return window.innerWidth >= 927
+              },
+              anchor: 'start',
+              align: 'top',
+              color: 'white',
+              offset: 10,
+              padding: 3,
+              borderRadius: 4,
+              backgroundColor (context) {
+                return context.dataset.borderColor
+              }
             }
           },
           {
@@ -117,9 +125,18 @@ export default {
             yAxisID: 'views-yAxe',
             order: 2,
             datalabels: {
-              display: true,
+              display () {
+                return window.innerWidth >= 927
+              },
+              anchor: 'start',
               align: 'end',
-              anchor: 'start'
+              padding: 3,
+              offset: 10,
+              color: 'white',
+              borderRadius: 4,
+              backgroundColor (context) {
+                return context.dataset.pointBackgroundColor
+              }
             }
           }
         ]
@@ -155,7 +172,10 @@ export default {
             borderDash: [3, 4]
           },
           ticks: {
-            beginAtZero: false
+            beginAtZero: true,
+            callback: (value, index, values) => {
+              return Math.round(value)
+            }
           },
           labels: {
             show: true
@@ -171,7 +191,10 @@ export default {
           ticks: {
             stepSize: 2,
             padding: 10,
-            beginAtZero: true // false
+            beginAtZero: true, // false.
+            callback: (value, index, values) => {
+              return Math.round(value)
+            }
           },
           labels: {
             show: false

--- a/components/users/statics.vue
+++ b/components/users/statics.vue
@@ -68,11 +68,12 @@
                   canvas-id="weeklyTraffic-chart"
                   :data="weekTrafficDataset"
                   :scales-x="[{ time: { stepSize: 1 } }]"
+                  :scales-y="[{ticks: { beginAtZero: false }}]"
                   use-data-label
                   responsive
                   user-x-axes-as-time
                   tooltip
-                  :data-label-opt="weekTrafficOpt"
+                  :data-label-opt="weekTrafficLabelOpt"
                   compute-scale-axe="Y"
                 />
               </b-col>
@@ -178,41 +179,34 @@ export default {
           displayFormats: {
             minute: 'h:mm a'
           },
-          stepSize: 4
+          stepSize: 3
         }
       }]
     },
     hoursTrafficOptionsYaxe () {
       return [{
         ticks: {
-          beginAtZero: false,
-          stepSize: 3
+          beginAtZero: false
+          // stepSize: 3
         }
       }]
     },
-    weekTrafficOpt () {
+    weekTrafficLabelOpt () {
       return {
         clip: false,
         align: 'center',
         anchor: 'center',
         formatter (value, context) {
           return value.y
-        },
-        display (context) {
-          return window.innerWidth >= 992
-        },
-        offset: 10,
-        padding: 6,
-        color: "white",
-        borderWidth: 2,
-        borderRadius: 14,
-        borderColor (context) {
-          return context.dataset.borderColor
-        },
-        backgroundColor (context) {
-          return context.dataset.borderColor
         }
       }
+    },
+    weeklyTrafficOptions () {
+      return [{
+        ticks: {
+          beginAtZero: true
+        }
+      }]
     }
   }
 }

--- a/mixins/chart/computingScaleTicksBarLine.js
+++ b/mixins/chart/computingScaleTicksBarLine.js
@@ -1,0 +1,71 @@
+export default {
+  data: () => ({}),
+  methods: {
+    computeDatasetRange (data, isBeginAtZero) {
+      let [max, min] = [Math.max.apply(null, data), Math.min.apply(null, data)]
+      const [maxWeight, minWeight] = [
+        (max % 10 === 0) ? 10 : 5,
+        (min % 10 === 0) ? 10 : 5
+      ]
+      max = Math.ceil(max / maxWeight) * maxWeight
+      min = isBeginAtZero ? 0 : Math.floor(min / minWeight) * minWeight
+      const diff = max - min
+      const [isStep5, isStep10] = [diff % 5 === 0, diff % 10 === 0]
+      return { max, min, isStep5, isStep10, isBeginAtZero, diff }
+    },
+    computingYScale (ranges) {
+      const [isAllPassStep5, isAllPassStep10] = [
+        ranges.every(({ isStep5 }) => isStep5 === true),
+        ranges.every(({ isStep10 }) => isStep10 === true)
+      ]
+
+      let commonStepWeight = null
+      if (isAllPassStep5 || isAllPassStep10) {
+        const diffs = ranges.map(({ diff }) => diff)
+        const maxDiff = Math.max.apply(null, diffs)
+        if (maxDiff >= 50) {
+          commonStepWeight = isAllPassStep5 && isAllPassStep10 ? 25 : isAllPassStep5 ? 25 : 20
+        } else if (maxDiff < 50 && maxDiff >= 10) {
+          commonStepWeight = isAllPassStep5 && isAllPassStep10 ? 5 : isAllPassStep5 ? 5 : 10
+        } else {
+          commonStepWeight = maxDiff % 5 === 0 ? 1 : maxDiff % 3 === 0 ? 3 : 2
+        }
+        const [maxs, mins] = [ranges.map(({ max }) => max), ranges.map(({ min }) => min)]
+        const [maxMax, minMin] = [Math.max.apply(null, maxs), Math.min.apply(null, mins)]
+        ranges = ranges.map(({ min, max, diff, isBeginAtZero }) => {
+          // Add Padding to max or min
+          if (maxMax === max) {
+            max += commonStepWeight
+          }
+          if (minMin === min && !isBeginAtZero) {
+            min -= commonStepWeight
+          }
+          // Re-estimate the difference
+          diff = max - min
+          const beginAtZero = isBeginAtZero && min === 0
+          const stepCount = diff / commonStepWeight
+          const stepSize = !commonStepWeight ? 0 : commonStepWeight
+          // Re-calculate max and min
+          if (!Number.isInteger(stepCount)) {
+            if (!beginAtZero) {
+              min = max - (Math.ceil(stepCount) * commonStepWeight)
+            } else {
+              max = min + (Math.ceil(stepCount) * commonStepWeight)
+            }
+          }
+          return { min, max, diff: max - min, beginAtZero, stepCount, stepSize }
+        })
+        const stepCounts = ranges.map(({ stepCount }) => stepCount)
+        const minStepCounts = Math.min.apply(null, stepCounts)
+        ranges = ranges.map((range, r) => {
+          if (range.stepCount !== minStepCounts) {
+            range.stepSize = (range.stepCount / minStepCounts) * range.stepSize
+            range.stepCount = (range.max - range.min) / commonStepWeight
+          }
+          return range
+        })
+      }
+      return ranges
+    }
+  }
+}

--- a/mixins/chart/defaultProps_linebar.js
+++ b/mixins/chart/defaultProps_linebar.js
@@ -143,7 +143,29 @@ export default {
       legend: {
         display: true
       }
-    }
+    },
+    dataLabelMap: {
+      line: 'lineDataLableOpt',
+      bar: 'barDataLableOpt'
+    },
+    lineDataLableOpt: {
+      padding: 6,
+      color: "white",
+      font: {
+        size: 10,
+        padding: 5
+      },
+      borderWidth: 2,
+      borderRadius: 25,
+      borderColor: '#fff',
+      backgroundColor (context) {
+        return context.dataset.borderColor
+      },
+      display () {
+        return window.innerWidth >= 992
+      }
+    },
+    barDataLableOpt: {}
   }),
   computed: {},
   watch: {
@@ -165,15 +187,15 @@ export default {
       this.data.datasets.forEach((dataset, d) => {
         const color = colors[d]
         if (dataset.type === 'line') {
-          dataset.backgroundColor = 'rgba(206, 212, 218, 0.8)' // color.background
-          dataset.pointBackgroundColor = color.border
+          dataset.backgroundColor = 'rgba(206, 212, 218, 0.8)'
+          dataset.pointBackgroundColor = color.rgb
           dataset.borderColor = color.rgb
-        } else if (dataset.type === 'bar') {
-          const rgbs = color.rgb
-          dataset.backgroundColor = color.background
-          dataset.pointBackgroundColor = rgbs
-          dataset.borderColor = color.border
           dataset.borderWidth = 1
+        } else if (dataset.type === 'bar') {
+          dataset.backgroundColor = color.background
+          dataset.pointBackgroundColor = color.rgb
+          dataset.borderColor = color.background
+          dataset.borderWidth = 0
         }
         dataset.fill = typeof dataset.fill === 'undefined' ? true : dataset.fill
       })
@@ -185,7 +207,8 @@ export default {
       if (!this.useDataLabel) {
         this.option.plugins.datalabels = false
       } else {
-        this.option.plugins.datalabels = !this.mixed ? this.mergeOptions(this.option.plugins.datalabels, this.dataLabelOpt) : this.dataLabelOpt
+        const chartDatalabels = this[this.dataLabelMap[this.type]]
+        this.option.plugins.datalabels = !this.mixed ? this.mergeOptions(chartDatalabels, this.dataLabelOpt) : this.dataLabelOpt
       }
 
       if (!this.tooltip) {

--- a/pages/overview.vue
+++ b/pages/overview.vue
@@ -65,13 +65,14 @@
                 canvas-id="sales-chart"
                 :data="sales"
                 :scales-x="[{ time: { stepSize: 3 } }]"
+                :scales-y="[{ticks: { beginAtZero: false }}]"
                 user-x-axes-as-time
                 tooltip
                 responsive
                 class="pb-xxl-3"
                 compute-scale-axe="Y"
                 use-data-label
-                :data-label-opt="salesOpt"
+                :data-label-opt="salesLableOpt"
               />
             </b-col>
           </b-row>
@@ -272,7 +273,7 @@ export default {
         }
       }
     },
-    salesOpt () {
+    salesLableOpt () {
       return {
         clip: false,
         align: 'center',
@@ -282,17 +283,6 @@ export default {
         },
         display (context) {
           return window.innerWidth >= 992 && context.dataIndex % 2
-        },
-        offset: 10,
-        padding: 3,
-        color: "white",
-        borderWidth: 2,
-        borderRadius: 14,
-        borderColor (context) {
-          return context.dataset.borderColor
-        },
-        backgroundColor (context) {
-          return context.dataset.borderColor
         }
       }
     },


### PR DESCRIPTION
## Work List
- Enhanced a feature of computing Y-axis scale range to line or bar chart

### Computing Y-axis scale range
1. Add **commonStepWeight** conditional
  - **_New_** : `maxDiff >= 50`
  - **_Existed_**: `maxDiff < 50 && maxDiff >= 10`, `maxDiff < 10`
2. Add _padding value_ to max or min
3. Check _stepSize_ and _stepCount_ for re-calculating max or min depending on padding value 

### The Range of step-size
1. `maxDiff >= 50`
    - `isAllPassStep5 && isAllPassStep10 ? 25 : isAllPassStep5 ? 25 : 20`
2. `maxDiff < 50 && maxDiff >= 10`
    - `isAllPassStep5 && isAllPassStep10 ? 5 : isAllPassStep5 ? 5 : 10`
3. `maxDiff < 10`
    - `maxDiff % 5 === 0 ? 1 : maxDiff % 3 === 0 ? 3 : 2`

close #72 