### PR TITLE
Feature/enhance chart color

### DIFF
--- a/components/chart/BarChart.vue
+++ b/components/chart/BarChart.vue
@@ -4,13 +4,11 @@
 
 <script>
 import defaultProps from "~/mixins/chart/defaultProps_linebar"
-import createChartColor from "~/mixins/chart/createChartColor"
 import computingYScaleBarLine from "~/mixins/chart/computingScaleTicksBarLine"
 
 export default {
   mixins: [
     defaultProps,
-    createChartColor,
     computingYScaleBarLine
   ],
   props: {
@@ -22,16 +20,8 @@ export default {
   },
   data: () => ({
     type: 'bar',
-    global: {
-      single: {
-        borderWidth: 1.5,
-        barPercentage: 0.4
-      },
-      multi: {
-        borderWidth: 1.5,
-        barPercentage: 0.5
-      }
-    },
+    borderWidth: 1.5,
+    barPercentage: 0.5,
     option: {
       elements: {
         rectangle: {
@@ -102,59 +92,30 @@ export default {
     },
     generateChartColor () {
       if (!this.data.datasets.length) {
-        return []
+        return this.data
+      }
+
+      if (this.singleColor) {
+        const colors = this.getRandomColors(this.data.datasets.length)
+        const rgbs = colors.map(({ rgb }) => rgb)
+        this.data.datasets.forEach((dataset, d) => {
+          dataset.borderWidth = this.borderWidth
+          dataset.barPercentage = this.barPercentage
+          const color = new Array(dataset.data.length).fill(rgbs[d])
+          dataset.backgroundColor = color
+          dataset.borderColor = color
+        })
       } else {
-        // eslint-disable-next-line no-lonely-if
-        if (this.singleColor) {
-          const colors = this.getRandomColors(this.data.datasets.length)
-          const rgbs = colors.map(({ rgb }) => rgb)
-          const option = this.global.single
-          this.data.datasets.forEach((dataset, d) => {
-            dataset.borderWidth = option.borderWidth
-            dataset.barPercentage = option.barPercentage
-            const color = new Array(dataset.data.length).fill(rgbs[d])
-            dataset.backgroundColor = color
-            dataset.borderColor = color
-            dataset.hoverBackgroundColor = color
-            dataset.hoverBorderColor = color
-          })
-        } else if (this.data.datasets.length < 2) {
-          const dataCount = this.data.datasets[0].data.length
-          const counts = this.colorTypes.length >= dataCount
-            ? Math.floor(this.colorTypes.length / dataCount)
-            : Math.floor(this.colorTypes.length * 4 / dataCount)
-          const option = this.global.single
-          let randomType = this.getRandomType()
-          let colors = this.getColorsByType(randomType)
-          let rgbs = []
-          if (counts < 2) {
-            randomType = this.getRandomType(counts)
-            colors = this.getColorsByType(randomType)
-            rgbs = colors.map(({ rgb }) => rgb)
-          } else {
-            randomType = this.getRandomType(counts, true)
-            colors = this.getColorsByType(randomType)
-            rgbs = colors.map(({ rgb }) => rgb)
-          }
-          this.data.datasets[0].borderWidth = option.borderWidth
-          this.data.datasets[0].barPercentage = option.barPercentage
-          this.data.datasets[0].backgroundColor = rgbs
-          this.data.datasets[0].borderColor = rgbs
-          this.data.datasets[0].hoverBackgroundColor = rgbs
-          this.data.datasets[0].hoverBorderColor = rgbs
-        } else {
-          const option = this.global.multi
-          const colors = this.getRandomColors(this.data.datasets[0].data.length)
-          const rgbs = colors.map(({ rgb }) => rgb)
-          this.data.datasets.forEach((dataset, d) => {
-            dataset.borderWidth = option.borderWidth
-            dataset.barPercentage = option.barPercentage
-            dataset.backgroundColor = rgbs[d]
-            dataset.borderColor = rgbs[d]
-            dataset.hoverBackgroundColor = rgbs[d]
-            dataset.hoverBorderColor = rgbs[d]
-          })
-        }
+        const singleDataSet = this.data.datasets.length < 2
+        const colors = this.getRandomColors(this.data.datasets[0].data.length)
+        const rgbs = colors.map(({ rgb }) => rgb)
+        this.data.datasets.forEach((dataset, d) => {
+          const rgb = singleDataSet ? rgbs : rgbs[d]
+          dataset.borderWidth = this.borderWidth
+          dataset.barPercentage = this.barPercentage
+          dataset.backgroundColor = rgb
+          dataset.borderColor = rgb
+        })
       }
     },
     computeScaleTicks (options) {

--- a/components/chart/DoughnutChart.vue
+++ b/components/chart/DoughnutChart.vue
@@ -2,13 +2,15 @@
   <canvas :id="canvasId" v-bind="{width, height}" />
 </template>
 <script>
-import defaultProps from "../../mixins/chart/defaultProps"
-import createChartColor from "~/mixins/chart/createChartColor"
+import defaultProps from "~/mixins/chart/defaultProps"
+import circleChartProps from '~/mixins/chart/props/circle'
+import chartColorCircle from '~/mixins/chart/color/circle'
 
 export default {
   mixins: [
     defaultProps,
-    createChartColor
+    circleChartProps,
+    chartColorCircle
   ],
   data: () => ({
     type: 'doughnut'
@@ -16,30 +18,10 @@ export default {
   mounted () {},
   methods: {
     generateChartColor () {
-      const [borderWidth, hoverBorderWidth] = [6, 3]
-      if (!this.data.datasets.length) {
-        return this.data
+      if (this.restMode) {
+        this.generateRestModeColor()
       } else {
-        // eslint-disable-next-line no-lonely-if
-        if (this.data.datasets.length < 2) {
-          const randomTypeIdx = this.getRandomIntInclusive(this.doughnutPieColorSets.length)
-          const colors = this.getColorsByType(this.doughnutPieColorSets[randomTypeIdx])
-          this.data.datasets[0].backgroundColor = colors
-          this.data.datasets[0].borderWidth = borderWidth
-          this.data.datasets[0].hoverBorderWidth = hoverBorderWidth
-        } else {
-          const counts = Math.round(this.totalColorCount / this.data.datasets.length)
-          const colors = new Array(counts).fill(null).reduce((colorSet, color, c) => {
-            const typeColors = this.getColorsByType(this.doughnutPieColorSets[c])
-            colorSet = colorSet.concat(typeColors)
-            return colorSet
-          }, [])
-          this.data.datasets.forEach((dataset, d) => {
-            dataset.backgroundColor = [colors[d].rgb, this.placeholderColor.rgb]
-            dataset.borderWidth = borderWidth
-            dataset.hoverBorderWidth = hoverBorderWidth
-          })
-        }
+        this.generateDefaultColor()
       }
     },
     renderChart () {

--- a/components/chart/LineChart.vue
+++ b/components/chart/LineChart.vue
@@ -2,14 +2,12 @@
   <canvas :id="canvasId" v-bind="{width, height}" />
 </template>
 <script>
-import createChartColor from "~/mixins/chart/createChartColor"
 import defaultProps from "~/mixins/chart/defaultProps_linebar"
 import computingYScaleBarLine from "~/mixins/chart/computingScaleTicksBarLine"
 
 export default {
   mixins: [
     defaultProps,
-    createChartColor,
     computingYScaleBarLine
   ],
   props: {
@@ -112,13 +110,7 @@ export default {
       return options
     },
     generateChartColor () {
-      let colors = null
-      if (this.data.datasets.length > 1) {
-        const colorsTypes = this.getRandomType(this.data.datasets.length)
-        colors = this.getColorsByType(colorsTypes)
-      } else {
-        colors = this.getRandomColors(this.data.datasets.length)
-      }
+      const colors = this.getRandomColors(this.data.datasets.length)
       colors.forEach(({ rgb, border, background }, c) => {
         this.data.datasets[c].backgroundColor = background
         this.data.datasets[c].pointBackgroundColor = border

--- a/components/chart/PieChart.vue
+++ b/components/chart/PieChart.vue
@@ -2,47 +2,27 @@
   <canvas :id="canvasId" v-bind="{width, height}" />
 </template>
 <script>
-import defaultProps from "../../mixins/chart/defaultProps"
-import createChartColor from "~/mixins/chart/createChartColor"
+import defaultProps from "~/mixins/chart/defaultProps"
+import circleChartProps from '~/mixins/chart/props/circle'
+import chartColorCircle from '~/mixins/chart/color/circle'
 
 export default {
   mixins: [
     defaultProps,
-    createChartColor
+    circleChartProps,
+    chartColorCircle
   ],
   data: () => ({
     type: 'pie'
   }),
   mounted () {},
   methods: {
-    generateChartColor () {
-      const dataCount = this.data.datasets.reduce((count, dataset) => {
-        count += dataset.data.length
-        return count
-      }, 0)
-      const counts = this.doughnutPieColorSets.length >= dataCount
-        ? Math.floor(this.doughnutPieColorSets.length / dataCount)
-        : Math.ceil(this.totalColorCount / dataCount)
-      const colors = new Array(counts).fill(null).reduce((colorSet, color, c) => {
-        const typeColors = this.getColorsByType(this.doughnutPieColorSets[c])
-        colorSet = colorSet.concat(typeColors)
-        return colorSet
-      }, [])
-      let colorLastIdx = 0
-      this.data.datasets = this.data.datasets.reduce((colored, dataset, d) => {
-        const dataColors = colors.slice(colorLastIdx, colorLastIdx + dataset.data.length)
-        dataset.backgroundColor = dataColors.map(({ rgb }) => rgb)
-        colored.push(dataset)
-        colorLastIdx = d + (dataset.data.length)
-        return colored
-      }, [])
-    },
     renderChart () {
       try {
         const ctx = document.getElementById(this.canvasId).getContext('2d')
         this.mergeDefaultOptions()
         const options = this.mergeOptions(this.option, this.customOpt)
-        this.generateChartColor()
+        this.generateDefaultColor()
         this.$chartjs.createChart(ctx, {
           type: this.type,
           data: this.data,

--- a/components/chart/PolarArea.vue
+++ b/components/chart/PolarArea.vue
@@ -2,44 +2,25 @@
   <canvas :id="canvasId" v-bind="{width, height}" />
 </template>
 <script>
-import defaultProps from "../../mixins/chart/defaultProps"
-import createChartColor from "~/mixins/chart/createChartColor"
+import defaultProps from "~/mixins/chart/defaultProps"
+import chartColorCircle from '~/mixins/chart/color/circle'
 
 export default {
   mixins: [
     defaultProps,
-    createChartColor
+    chartColorCircle
   ],
   data: () => ({
     type: 'polarArea'
   }),
   mounted () {},
   methods: {
-    generateChartColor () {
-      const dataCount = this.data.datasets.reduce((count, dataset) => {
-        count += dataset.data.length
-        return count
-      }, 0)
-      const counts = this.colorTypes.length >= dataCount
-        ? Math.floor(this.colorTypes.length / dataCount)
-        : Math.floor(this.colorTypes.length * 4 / dataCount)
-      const randomType = this.getRandomType(counts, true)
-      const colors = this.getColorsByType(randomType)
-      let colorLastIdx = 0
-      this.data.datasets = this.data.datasets.reduce((colored, dataset, d) => {
-        const dataColors = colors.slice(colorLastIdx, colorLastIdx + dataset.data.length)
-        dataset.backgroundColor = dataColors.map(({ rgb }) => rgb)
-        colored.push(dataset)
-        colorLastIdx = d + (dataset.data.length)
-        return colored
-      }, [])
-    },
     renderChart () {
       try {
         const ctx = document.getElementById(this.canvasId).getContext('2d')
         this.mergeDefaultOptions()
         const options = this.mergeOptions(this.option, this.customOpt)
-        this.generateChartColor()
+        this.generateDefaultColor()
         this.$chartjs.createChart(ctx, {
           type: this.type,
           data: this.data,

--- a/components/event/details/trafficSoureces.vue
+++ b/components/event/details/trafficSoureces.vue
@@ -22,6 +22,7 @@
               :circumference="0.5"
               use-data-label
               :data-label-opt="trafficLabelOpt"
+              :rest-mode="true"
               responsive
             />
           </client-only>

--- a/mixins/chart/color/circle.js
+++ b/mixins/chart/color/circle.js
@@ -1,0 +1,30 @@
+export default {
+  methods: {
+    generateRestModeColor () {
+      if (!this.data.datasets.length) {
+        return this.data
+      }
+
+      const colors = this.getRandomColors(this.data.datasets.length)
+      this.data.datasets.forEach((dataset, d) => {
+        dataset.backgroundColor = [colors[d].rgb, this.placeholder.rgb]
+        dataset.borderWidth = this.borderWidth
+        dataset.hoverBorderWidth = this.hoverBorderWidth
+      })
+    },
+    generateDefaultColor () {
+      if (!this.data.datasets.length) {
+        return this.data
+      }
+
+      const dataCount = this.data.datasets.reduce((count, { data }) => count + data.length, 0)
+      let colorLastIdx = 0
+      const colors = this.getRandomColors(dataCount)
+      this.data.datasets.forEach((dataset, d) => {
+        const dataColors = colors.slice(colorLastIdx, colorLastIdx + dataset.data.length)
+        dataset.backgroundColor = dataColors.map(({ rgb }) => rgb)
+        colorLastIdx = d + (dataset.data.length)
+      })
+    }
+  }
+}

--- a/mixins/chart/colorSet.js
+++ b/mixins/chart/colorSet.js
@@ -36,3 +36,19 @@ export const colorSet = [
   // { type: "", rgb: "", background: "rgba(, .5)", border: "rgb(224, 224, 224)" },
   // { type: "", rgb: "", background: "rgba(, .5)", border: "rgb(189, 189, 189)" },
 ]
+
+export const placeholderColor = { rgb: 'rgba(206, 212, 218, 1)' }
+
+export const extendedColors = [
+  { rgb: 'rgb(8, 48, 107)', background: 'rgba(8, 48, 107, .7)', border: 'rgb(255, 255, 255)', text: 'rgb(255, 255, 255)' },
+  { rgb: 'rgb(8, 81, 156)', background: 'rgba(8, 81, 156, .7)', border: 'rgb(255, 255, 255)', text: 'rgb(255, 255, 255)' },
+  { rgb: 'rgb(33, 113, 181)', background: 'rgba(33, 113, 181, .7)', border: 'rgb(255, 255, 255)', text: 'rgb(255, 255, 255)' },
+  { rgb: 'rgb(66, 146, 198)', background: 'rgba(66, 146, 198, .7)', border: 'rgb(255, 255, 255)', text: 'rgb(255, 255, 255)' },
+  { rgb: 'rgb(3, 155, 229)', background: 'rgba(3, 155, 229, .7)', border: 'rgb(255, 255, 255)', text: 'rgb(255, 255, 255)' },
+  { rgb: 'rgb(3, 169, 244)', background: 'rgba(3, 169, 244, .7)', border: 'rgb(255, 255, 255)', text: 'rgb(255, 255, 255)' },
+  { rgb: 'rgb(41, 182, 246)', background: 'rgba(41, 182, 246, .7)', border: 'rgb(224, 224, 224)', text: 'rgb(224, 224, 224)' },
+  { rgb: 'rgb(79, 195, 247)', background: 'rgba(79, 195, 247, .7)', border: 'rgb(224, 224, 224)', text: 'rgb(224, 224, 224)' }
+  // { rgb: 'rgb(158, 202, 225)', border: 'rgb(224, 224, 224)', text: 'rgb(224, 224, 224)' },
+  // { rgb: 'rgb(198, 219, 239)', border: 'rgb(189, 189, 189)', text: 'rgb(189, 189, 189)' },
+  // { rgb: 'rgb(222, 235, 247)', border: 'rgb(189, 189, 189)', text: 'rgb(189, 189, 189)' }
+]

--- a/mixins/chart/createChartColor.js
+++ b/mixins/chart/createChartColor.js
@@ -1,91 +1,36 @@
 // /chart/createChartColor.js
-import { colorTypes, colorSet } from './colorSet'
+import { extendedColors, placeholderColor } from './colorSet'
 
 export default {
   data: () => ({
-    colorTypes,
-    colorSet,
-    doughnutPieColorSets: [
-      'Blue',
-      'Indigo',
-      'BlueGray'
-    ]
+    colorSet: extendedColors,
+    placeholder: placeholderColor
   }),
   computed: {
     totalColorCount () {
-      return this.doughnutPieColorSets.length * 4
-    },
-    placeholderColor () {
-      return this.colorSet.find(color => color.type === 'placeholder')
+      return this.colorSet.length
     }
   },
   created () {},
   mounted () {},
   methods: {
-    getRandomIntInclusive (max = this.colorSet.length - 1, min = 0) {
+    getRandomIntInclusive (max = this.totalColorCount - 1, min = 0) {
       min = Math.ceil(min)
       max = Math.floor(max)
       return Math.floor(Math.random() * (max - min + 1)) + min
-    },
-    getRandomType (count = this.colorTypes.length, multi = false) {
-      if (!multi) {
-        const randomTypeIdx = this.getRandomIntInclusive(this.colorTypes.length - 1)
-        return this.colorTypes[randomTypeIdx]
-      } else {
-        const [typesIdx, max] = [[], this.colorTypes.length - 1]
-        let r = 0
-        do {
-          let random = this.getRandomIntInclusive(max)
-          random = random === 0 ? 0 : random - 1
-          const accumulated = typesIdx[r - 1] === random
-          if ((!typesIdx.includes(random) || (typesIdx.includes(random) && typesIdx.length < count)) && !accumulated) {
-            typesIdx.push(random)
-            r = ++r
-          }
-        } while (typesIdx.length < count)
-        const types = typesIdx.reduce((filled, idx) => {
-          filled.push(this.colorTypes[idx])
-          return filled
-        }, [])
-        return types
-      }
     },
     getRandomColor () {
       const random = this.getRandomIntInclusive()
       return this.colorSet[random]
     },
     getRandomColors (count = 5) {
-      const paletteIdx = []
-      while (paletteIdx.length < count) {
-        const random = this.getRandomIntInclusive()
-        if (!paletteIdx.includes(random)) {
-          paletteIdx.push(random)
-        }
+      const randomStart = this.getRandomIntInclusive()
+      let randomPalette = this.colorSet.slice(randomStart, count)
+      if (Math.abs(count - randomPalette.length) > 0) {
+        const overPalette = this.colorSet.slice(0, count - randomPalette.length)
+        randomPalette = [...overPalette, ...randomPalette]
       }
-      const palette = paletteIdx.reduce((filled, idx) => {
-        filled.push(this.colorSet[idx])
-        return filled
-      }, [])
-      return palette
-    },
-    getColorsByType (types) {
-      if (typeof types === 'string') {
-        if (!types || !colorTypes.includes(types)) {
-          types = colorTypes[Math.floor(Math.random() * colorTypes.length)]
-        }
-        const typeColors = this.colorSet.filter(({ type }) => types === type)
-        return typeColors
-      } else {
-        types = types.map((type) => {
-          if (!colorTypes.includes(type)) {
-            return colorTypes[Math.floor(Math.random() * colorTypes.length)]
-          } else {
-            return type
-          }
-        })
-        const typeColors = this.colorSet.filter(({ type }) => types.includes(type))
-        return typeColors
-      }
+      return randomPalette
     }
   }
 }

--- a/mixins/chart/defaultProps.js
+++ b/mixins/chart/defaultProps.js
@@ -1,8 +1,10 @@
 import mergeOptions from '~/mixins/chart/mergeOptions'
+import createChartColor from "~/mixins/chart/createChartColor"
 
 export default {
   mixins: [
-    mergeOptions
+    mergeOptions,
+    createChartColor
   ],
   props: {
     responsive: {
@@ -92,26 +94,11 @@ export default {
       default: (customLegendClickProps) => {
         return typeof customLegendClickProps === 'undefined' ? false : customLegendClickProps
       }
-    },
-    halfSize: {
-      type: Boolean,
-      required: false,
-      default: (halfChartProps) => {
-        return typeof halfChartProps === 'undefined' ? false : halfChartProps
-      }
-    },
-    rotation: {
-      type: Number,
-      required: false,
-      default: 1
-    },
-    circumference: {
-      type: Number,
-      required: false,
-      default: 1
     }
   },
   data: () => ({
+    borderWidth: 6,
+    hoverBorderWidth: 3,
     option: {
       responsive: true,
       maintainAspectRatio: false,

--- a/mixins/chart/defaultProps_linebar.js
+++ b/mixins/chart/defaultProps_linebar.js
@@ -1,8 +1,10 @@
 import mergeOptions from '~/mixins/chart/mergeOptions'
+import createChartColor from "~/mixins/chart/createChartColor"
 
 export default {
   mixins: [
-    mergeOptions
+    mergeOptions,
+    createChartColor
   ],
   props: {
     responsive: {
@@ -131,6 +133,8 @@ export default {
     }
   },
   data: () => ({
+    borderWidth: 6,
+    hoverBorderWidth: 3,
     option: {
       responsive: true,
       maintainAspectRatio: false,
@@ -187,7 +191,7 @@ export default {
       this.data.datasets.forEach((dataset, d) => {
         const color = colors[d]
         if (dataset.type === 'line') {
-          dataset.backgroundColor = 'rgba(206, 212, 218, 0.8)'
+          dataset.backgroundColor = color.border // 'rgba(206, 212, 218, 0.8)'
           dataset.pointBackgroundColor = color.rgb
           dataset.borderColor = color.rgb
           dataset.borderWidth = 1

--- a/mixins/chart/props/circle.js
+++ b/mixins/chart/props/circle.js
@@ -1,0 +1,26 @@
+export default {
+  props: {
+    halfSize: {
+      type: Boolean,
+      required: false,
+      default: (halfChartProps) => {
+        return typeof halfChartProps === 'undefined' ? false : halfChartProps
+      }
+    },
+    rotation: {
+      type: Number,
+      required: false,
+      default: 1
+    },
+    circumference: {
+      type: Number,
+      required: false,
+      default: 1
+    },
+    restMode: {
+      type: Boolean,
+      required: false,
+      default: false
+    }
+  }
+}


### PR DESCRIPTION
## Work List

- Integrate chart colorSet
   - Delete colors except blue type color
   - Delete **colorType system**
   - Pick-up or Randomly generate colorSet on color level. not **colorType system**
- Enhanced a feature of generating chart color
  - Circle type chart: Doughnut, Pie, Polar
  - Others: Line, Bar
- Export Circle type chart's props from **defaultProps.js**
- Create a mixin for common feature of generating circle type chart's color 
   - Doughnut, Pie, Polar Chart