### PR TITLE
Hotfix/build deploy fail

### DIFF
--- a/env/.env.production
+++ b/env/.env.production
@@ -2,4 +2,4 @@ AXIOS_BASEURL = https://nuxt-bootstrap-dashboard.herokuapp.com/,
 ROUTER_BASEURL = /
 BOOTSTRAP_VUE_NO_WARN = false
 BUILD_DIR = .nuxt_production
-BUILD_ANALYZE_DIR = false
+BUILD_ANALYZE_DIR = null

--- a/env/.env.staging
+++ b/env/.env.staging
@@ -2,4 +2,4 @@ AXIOS_BASEURL = https://nuxt-bootstrap-dashboard-stage.herokuapp.com/
 ROUTER_BASEURL = /
 BOOTSTRAP_VUE_NO_WARN = true
 BUILD_DIR = .nuxt_staging
-BUILD_ANALYZE_DIR = false
+BUILD_ANALYZE_DIR = null

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -2,6 +2,10 @@ import bodyParser from 'body-parser'
 import { extendRoutes } from './router'
 const processEnv = require('dotenv').config({ path: `./env/.env.${process.env.NODE_ENV}` }).parsed
 
+if (process.env.NODE_ENV !== 'production') {
+  console.log(`process.env.NODE_ENV => ${process.env.NODE_ENV}`)
+}
+
 export default {
   // Global page headers: https://go.nuxtjs.dev/config-head
   head: {
@@ -127,7 +131,7 @@ export default {
   ],
 
   // buildDir Configuration: https://nuxtjs.org/docs/configuration-glossary/configuration-builddir
-  buildDir: process.env.ANALYZE === 'false' ? processEnv.BUILD_DIR : processEnv.BUILD_ANALYZE_DIR,
+  buildDir: process.env.BUILD_ANALYZE_DIR === 'null' ? processEnv.BUILD_DIR : processEnv.BUILD_ANALYZE_DIR,
 
   // Build Configuration: https://go.nuxtjs.dev/config-build
   build: {
@@ -135,10 +139,12 @@ export default {
       compact: true
     },
     devtools: processEnv.NODE_ENV !== 'production',
-    analyze: {
-      analyzerMode: 'server',
-      analyzerHost: '0',
-      openAnalyzer: true
-    }
+    analyze: process.env.BUILD_ANALYZE_DIR === 'null'
+      ? false
+      : {
+          analyzerMode: 'server',
+          analyzerHost: '0',
+          openAnalyzer: process.env.BUILD_ANALYZE_DIR !== 'false'
+        }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "npm": "6.x"
   },
   "scripts": {
-    "dev": "nodemon --watch mixins --watch api --watch env --exec \"cross-env ANALYZE=false NODE_ENV=development nuxt\"",
-    "build": "nuxt build",
-    "analyze": "cross-env ANALYZE=true NODE_ENV=development nuxt build --analyze",
-    "start": "cross-env ANALYZE=false nuxt start",
+    "dev": "nodemon --watch mixins --watch api --watch env --exec \"cross-env NODE_ENV=development nuxt\"",
+    "analyze": "cross-env nuxt build --analyze",
+    "build": "cross-env nuxt build",
+    "start": "cross-env nuxt start",
     "generate": "nuxt generate",
     "lint:js": "eslint --ext \".js,.vue\" --ignore-path .gitignore .",
     "lint": "npm run lint:js",


### PR DESCRIPTION
## Work List
- Fixed the bug of fail to build and deploy
  - build and deploy is failed cause `buildDir` option is set the wrong value

### Details
- Fixed the bug of `buildDir` option in `nuxt.config.js`
  - if `process.env.BUILD_ANALYZE_DIR` has value as `not null`, it will build in its directory
  - else it will build in `process.env.BUILD_DIR` directory

close #139 