### PR TITLE
Delete cross-env dependency to deploy on production

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "dev": "nodemon --watch mixins --watch api --watch env --exec \"cross-env NODE_ENV=development nuxt\"",
     "analyze": "cross-env nuxt build --analyze",
-    "build": "cross-env nuxt build",
-    "start": "cross-env nuxt start",
+    "build": "nuxt build",
+    "start": "nuxt start",
     "generate": "nuxt generate",
     "lint:js": "eslint --ext \".js,.vue\" --ignore-path .gitignore .",
     "lint": "npm run lint:js",


### PR DESCRIPTION
## Work List
- Delete `cross-env` dependency to `npm start` script in `package.json`
- `cross-env` dependency occurred dependency reference error when build on the production server

