### PR TITLE
Delete comma to AXIOS_BASEURL

### DIFF
--- a/env/.env.production
+++ b/env/.env.production
@@ -1,4 +1,4 @@
-AXIOS_BASEURL = https://nuxt-bootstrap-dashboard.herokuapp.com/,
+AXIOS_BASEURL = https://nuxt-bootstrap-dashboard.herokuapp.com/
 ROUTER_BASEURL = /
 BOOTSTRAP_VUE_NO_WARN = false
 BUILD_DIR = .nuxt_production


### PR DESCRIPTION
## Work List
- Fix the bug of api throw error on production level

### Details
- Delete comma to the `AXIOS_BASEURL` variable on the`.env.production`