### PR TITLE
Hotfix/#189 index page fragment error

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,8 +1,8 @@
 <template>
   <fragment>
     <BaseNav />
-    <main>
-      <b-row id="header" :class="['mx-0 landingIntro', { loaded }]">
+    <section id="jumbotron">
+      <b-row id="header" :class="['mx-0 landingIntro', { loaded }]" tag="article">
         <b-col
           cols="12"
           :class="['text-white pt-4 pb-5 py-sm-0', 'landingIntro__content', { collapsed: collpased.column1 }]"
@@ -12,13 +12,18 @@
               <span class="font-weight-light">Welcome to</span>
               <span class="landingIntro__service">Nuxtrap</span>
             </h1>
-            <div :class="['d-none d-md-block text-light landingIntro__text', { collapsed: collpased.column1 }]">
+            <div :class="['d-none d-md-block text-light landingIntro__text mb-md-5', { collapsed: collpased.column1 }]">
               <h3 class="font-weight-light mb-1 landingIntro__description">Developed Admin Dashboard Propject</h3>
               <h3 class="font-weight-light mb-2 mb-md-0 landingIntro__description">with <i>Nuxt.js</i> and <i>Bootstrap</i>.</h3>
             </div>
-            <h3 :class="['d-block d-md-none font-weight-light text-light mb-2 mb-md-0 landingIntro__description landingIntro__text', { collapsed: collpased.column1 }]">
+            <h3 :class="['d-block d-md-none font-weight-light text-light mb-4 mb-md-0 landingIntro__description landingIntro__text', { collapsed: collpased.column1 }]">
               Developed Admin Dashboard Propject with <i>Nuxt.js</i> and <i>Bootstrap</i>.
             </h3>
+            <div class="d-inline-block fs-4 text-light font-italic border py-2 px-3 border-light rounded-pill shadow-lg">
+              <nuxt-link :to="{ name: 'overview'}" class="text-light text-decoration-none">
+                Let's start explore! <BIconLightningFill />
+              </nuxt-link>
+            </div>
           </div>
         </b-col>
         <template v-if="collpased.column2">
@@ -42,20 +47,22 @@
           </b-col>
         </template>
       </b-row>
-      <Nuxt />
-    </main>
+    </section>
+    <Nuxt />
     <BaseFooter />
   </fragment>
 </template>
 
 <script>
 import { Fragment } from 'vue-fragment'
+import { BIconLightningFill } from 'bootstrap-vue'
 import lazyLoad from '~/mixins/lazyLoad'
 
 export default {
   name: "Default",
   components: {
-    Fragment
+    Fragment,
+    BIconLightningFill
   },
   mixins: [
     lazyLoad
@@ -230,7 +237,7 @@ export default {
 }
 
 .landingIntro__title {
-  margin-bottom: 2.5rem;
+  margin-bottom: 1.5rem;
   @media (max-width: 1199.98px) {
     font-size: 3rem;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16566,6 +16566,11 @@
         }
       }
     },
+    "vue-fragment": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/vue-fragment/-/vue-fragment-1.5.1.tgz",
+      "integrity": "sha512-ig6eES6TcMBbANW71ylB+AJgRN+Zksb3f50AxjGpAk6hMzqmeuD80qeh4LJP0jVw2dMBMjgRUfIkrvxygoRgtQ=="
+    },
     "vue-functional-data-merge": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vue-functional-data-merge/-/vue-functional-data-merge-3.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16566,11 +16566,6 @@
         }
       }
     },
-    "vue-fragment": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/vue-fragment/-/vue-fragment-1.5.2.tgz",
-      "integrity": "sha512-KEW0gkeNOLJjtXN4jqJhTazez5jtrwimHkE5Few/VxblH4F9EcvJiEsahrV5kg5uKd5U8du4ORKS6QjGE0piYA=="
-    },
     "vue-functional-data-merge": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vue-functional-data-merge/-/vue-functional-data-merge-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "nuxt": "^2.15.3",
     "uuid": "^8.3.2",
     "vue-chartjs": "^3.5.1",
+    "vue-fragment": "^1.5.1",
     "vuex": "^3.6.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "nuxt": "^2.15.3",
     "uuid": "^8.3.2",
     "vue-chartjs": "^3.5.1",
-    "vue-fragment": "^1.5.2",
     "vuex": "^3.6.2"
   },
   "devDependencies": {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,6 +1,5 @@
 <template>
-  <b-container fluid tag="section">
-    <!-- flex-column -->
+  <b-container fluid tag="main">
     <subHeadingSection />
     <!-- Features -->
     <featuresSection />


### PR DESCRIPTION
## Work List
- Fix the bug of the **vue-fragment** package
- Change the layout and page's HTML Construction.
- Add a link of the `Go to overview` page

### Details
- Downgrade **vue-fragment** version from `^1.5.2` to `^1.5.1` to resolve `Failed to execute 'insertBefore' on 'Node' ` error
   - Refer https://github.com/Thunberg087/vue-fragment/issues/61
- Move `main` tag into `/pages/index.vue` as `b-container`
- Wrap `/pages/index.vue` contents with `b-container` for single root element

close #189 
