### PR TITLE
Feature/#191 enhance dashboard layout page transition

### DIFF
--- a/assets/styles/custom/fade.scss
+++ b/assets/styles/custom/fade.scss
@@ -9,8 +9,9 @@
 }
 
 // fade transition for dashboard content
-.dashboard-fade-enter-active {
-  transition: opacity 1s;
+.dashboard-fade-enter-active,
+.dashboard-fade-leave-active {
+  transition: opacity 0.5s;
 }
 
 .dashboard-fade-enter,

--- a/components/loadingWrapper.vue
+++ b/components/loadingWrapper.vue
@@ -37,7 +37,7 @@ export default {
 }
 
 .loadingFade-enter-active {
-  transition: opacity 0.5s;
+  transition: opacity 0s;
 }
 
 .loadingFade-leave-active {

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -41,12 +41,24 @@ export default {
           this.collapseSidebar(true)
         }, 1000)
       }
+    },
+    $route: {
+      handler (now, past) {
+        const isUseLayoutRouteWatcher = now.meta.useLayoutRouteWatcher
+        if (isUseLayoutRouteWatcher || typeof isUseLayoutRouteWatcher === 'undefined') {
+          if (now.name !== past.name) {
+            this.isChildPending = true
+          }
+        }
+      }
     }
   },
   created () {
     this.$nuxt.$on('pageLoading', (status) => {
       const _status = typeof status === 'undefined' ? false : status
-      this.$set(this, 'isChildPending', _status)
+      if (!_status) {
+        this.isChildPending = _status
+      }
     })
   },
   mounted () {

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -35,19 +35,17 @@ export default {
         this.collapseSidebar(aft)
       }
     },
-    isChildPending (aft, prev) {
-      if (this.isMobile && !this.collapsedSidebar && (prev && !aft)) {
-        setTimeout(() => {
-          this.collapseSidebar(true)
-        }, 1000)
-      }
-    },
     $route: {
       handler (now, past) {
         const isUseLayoutRouteWatcher = now.meta.useLayoutRouteWatcher
         if (isUseLayoutRouteWatcher || typeof isUseLayoutRouteWatcher === 'undefined') {
           if (now.name !== past.name) {
             this.isChildPending = true
+            if (this.isMobile) {
+              setTimeout(() => {
+                this.collapseSidebar(true)
+              }, 500)
+            }
           }
         }
       }

--- a/mixins/watchFetchStatePending.js
+++ b/mixins/watchFetchStatePending.js
@@ -1,0 +1,23 @@
+export default {
+  name: 'watchFetchStatePending',
+  data () {
+    return {}
+  },
+  watch: {
+    '$fetchState.pending': {
+      handler (state) {
+        if (!state) {
+          this.$nuxt.$emit('pageLoading', false)
+        }
+      }
+    }
+  },
+  computed: {},
+  created () {},
+  mounted () {
+    if (this.$fetchState.pending === false) {
+      this.$nuxt.$emit('pageLoading', false)
+    }
+  },
+  methods: {}
+}

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -151,13 +151,16 @@
 <script>
 import dayjs from "dayjs"
 import { mapGetters } from "vuex"
+import watchFetchStatePending from '~/mixins/watchFetchStatePending'
 
 export default {
   name: 'Events',
   components: {
     EventStatics: () => import('~/components/event/statics.vue')
   },
-  mixins: [],
+  mixins: [
+    watchFetchStatePending
+  ],
   provide () {
     return {
       parentRef: this.$refs
@@ -294,16 +297,6 @@ export default {
     },
     eventTrafficsCustomOpt () {
       return new Array(this.eventTraffics.datasets.length).fill({ fill: false })
-    }
-  },
-  watch: {
-    '$fetchState.pending': {
-      immediate: true,
-      handler (state) {
-        if (typeof state !== 'undefined') {
-          this.$nuxt.$emit('pageLoading', state)
-        }
-      }
     }
   },
   created () {},

--- a/pages/events/list.vue
+++ b/pages/events/list.vue
@@ -327,6 +327,7 @@
 import { mapGetters } from "vuex"
 import searchEvent from '~/mixins/event/searchEvent'
 import computeScheduledEvent from '~/mixins/event/computeScheduledEvent'
+import watchFetchStatePending from '~/mixins/watchFetchStatePending'
 
 export default {
   name: 'Events',
@@ -336,7 +337,8 @@ export default {
   },
   mixins: [
     searchEvent,
-    computeScheduledEvent
+    computeScheduledEvent,
+    watchFetchStatePending
   ],
   provide () {
     return {
@@ -435,16 +437,6 @@ export default {
     },
     globalDisabled () {
       return this.tableToolBarDisabled || this.isDeletingEvent
-    }
-  },
-  watch: {
-    '$fetchState.pending': {
-      immediate: true,
-      handler (state) {
-        if (typeof state !== 'undefined') {
-          this.$nuxt.$emit('pageLoading', state)
-        }
-      }
     }
   },
   created () {},

--- a/pages/overview.vue
+++ b/pages/overview.vue
@@ -162,8 +162,12 @@
 </template>
 
 <script>
+import watchFetchStatePending from '~/mixins/watchFetchStatePending'
 
 export default {
+  mixins: [
+    watchFetchStatePending
+  ],
   layout: 'dashboard',
   data: () => ({
     res: null,
@@ -303,16 +307,6 @@ export default {
     trafficChannelLabelsOpt () {
       return {
         color: '#fff'
-      }
-    }
-  },
-  watch: {
-    '$fetchState.pending': {
-      immediate: true,
-      handler (state) {
-        if (typeof state !== 'undefined') {
-          this.$nuxt.$emit('pageLoading', state)
-        }
       }
     }
   },

--- a/pages/users/index.vue
+++ b/pages/users/index.vue
@@ -161,6 +161,7 @@
 <script>
 import { mapGetters } from "vuex"
 import searchUser from '~/mixins/user/searchUser'
+import watchFetchStatePending from '~/mixins/watchFetchStatePending'
 
 export default {
   name: 'UserIdx',
@@ -169,7 +170,8 @@ export default {
     UsersFilter: () => import('~/components/users/filter')
   },
   mixins: [
-    searchUser
+    searchUser,
+    watchFetchStatePending
   ],
   provide () {
     return {
@@ -266,16 +268,6 @@ export default {
     },
     isTableBusy () {
       return this.isSearching || this.isResetting || this.isSearchingUsername || this.isResettingForm
-    }
-  },
-  watch: {
-    '$fetchState.pending': {
-      immediate: true,
-      handler (state) {
-        if (typeof state !== 'undefined') {
-          this.$nuxt.$emit('pageLoading', state)
-        }
-      }
     }
   },
   methods: {

--- a/pages/users/list.vue
+++ b/pages/users/list.vue
@@ -218,6 +218,7 @@
 <script>
 import { mapGetters } from "vuex"
 import searchUser from '~/mixins/user/searchUser'
+import watchFetchStatePending from '~/mixins/watchFetchStatePending'
 
 export default {
   name: 'UserList',
@@ -227,7 +228,8 @@ export default {
     UsersPaymentsStatics: () => import('~/components/users/static/payments')
   },
   mixins: [
-    searchUser
+    searchUser,
+    watchFetchStatePending
   ],
   provide () {
     return {
@@ -333,16 +335,6 @@ export default {
     },
     isTableBusy () {
       return this.isSearching || this.isResetting || this.isSearchingUsername || this.isResettingForm
-    }
-  },
-  watch: {
-    '$fetchState.pending': {
-      immediate: true,
-      handler (state) {
-        if (typeof state !== 'undefined') {
-          this.$nuxt.$emit('pageLoading', state)
-        }
-      }
     }
   },
   methods: {

--- a/pages/users/statics.vue
+++ b/pages/users/statics.vue
@@ -118,6 +118,7 @@
 <script>
 import dayjs from "dayjs"
 import { mapGetters } from "vuex"
+import watchFetchStatePending from '~/mixins/watchFetchStatePending'
 
 export default {
   name: 'UserStatics',
@@ -125,6 +126,9 @@ export default {
     UsersAuthStatics: () => import('~/components/users/static/authentication'),
     UsersPaymentsStatics: () => import('~/components/users/static/payments')
   },
+  mixins: [
+    watchFetchStatePending
+  ],
   layout: 'dashboard',
   props: {},
   data: () => ({
@@ -232,16 +236,6 @@ export default {
           beginAtZero: true
         }
       }]
-    }
-  },
-  watch: {
-    '$fetchState.pending': {
-      immediate: true,
-      handler (state) {
-        if (typeof state !== 'undefined') {
-          this.$nuxt.$emit('pageLoading', state)
-        }
-      }
     }
   },
   methods: {}

--- a/router.js
+++ b/router.js
@@ -69,7 +69,7 @@ export function extendRoutes (routes, resolve) {
       path: '/events/event/:id',
       component: resolve(__dirname, 'pages/events/_id'),
       chunkName: 'pages/event/_id',
-      meta: { parent: 'events' }
+      meta: { parent: 'events', useLayoutRouteWatcher: false }
     },
     {
       name: 'userStatics',
@@ -90,7 +90,7 @@ export function extendRoutes (routes, resolve) {
       path: '/users/user/:id',
       component: resolve(__dirname, 'pages/users/_id'),
       chunkName: 'pages/users/_id',
-      meta: { parent: 'users' }
+      meta: { parent: 'users', useLayoutRouteWatcher: false }
     },
     {
       name: 'notFound',


### PR DESCRIPTION
## Work List
- Enhanced a feature of **dashboard** layout transition

### Details
- Edit the transition-timing of `dashboard-fade-leave-active`, `loadingFade-enter-active`
  - Set `dashboard-fade-leave-active` transition-timing same as the `dashboard-fade-active-active`
  - Set 0s to `loadingFade-enter-active`
- Change the handling of the `isChildPending` state
   - create the  common mixin of handling `fetchState.pending` state for dashboard pages
   - handler
      - `$route` watch property in the `/layout/dashboard`
      - `$fetchState.pending` watch property in the dashboard pagea imported from `/mixins/watchFetchStatePending.js`
- Collapse sidebar when route is changed on mobile

Close #191 